### PR TITLE
Add extra command to build tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 all: lint build
 
+tools:
+	docker build -t mtneug/freetz .
+.PHONY: tools 
+
 build:
 	docker build -t mtneug/freetz .
 .PHONY: build

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ $ docker run --rm -it -v $PWD/images:/freetz/images -v $PWD/config:/.config mtne
 # Build with patches
 # put your .patch files into $PWD/patches
 $ docker run --rm -it -v $PWD/patches:/patches -v $PWD/images:/freetz/images mtneug/freetz
+
+# Build tools
+$ docker run --rm -it -v $PWD/tools:/freetz/tools mtneug/freetz tools
 ```
 
 There are also some other commands:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,6 +10,7 @@ print_usage() {
   echo "                            This is only possible if there already"
   echo "                            exists a .config file in the root directory."
   echo "  clean                   Removes build output"
+  echo "  tools                   Build tools"
   echo "  help                    Prints this usage information"
   echo "  [cmd] [args...]         Runs [cmd] with given arguments"
 }
@@ -28,7 +29,12 @@ clean() {
   rm -rf images/*
 }
 
-build() {
+tools() {
+  checkout "$@"
+  make tools
+}
+
+checkout() {
   test "$#" -ge 1 || error "no branch specified"
   rev=$1
   shift
@@ -40,6 +46,10 @@ build() {
   git remote add origin "https://github.com/Freetz/freetz.git"
   git fetch
   git checkout "$rev"
+}
+
+build() {
+  checkout "$@"
 
   echo "apply patches..."
   for p in /patches/*.patch; do
@@ -76,6 +86,9 @@ main() {
   case $cmd in
     build)
       build "$@"
+      ;;
+    tools)
+      tools "$@"
       ;;
     help)
       print_usage


### PR DESCRIPTION
Added an extra command to build the toolset included in freetz.

I initially tried to do that by running `make tools` as  a container CMD but that doesn't work as the sources need to be cloned first.